### PR TITLE
feat(search): self-hosted Meilisearch site search for zh/en

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ vendored), heavily overridden by repo-level layouts/.
 - assets/ts/ — first-party TypeScript (no jQuery/lightbox2: theme-init
   + theme-toggle, site-controls, sidebar-toc, back-to-top, copy-code,
   image-viewer = native <dialog> lightbox, utterances-init, analytics,
-  footer-year), compiled per-entry to /js/<name>.<hash>.js by
+  footer-year, search), compiled per-entry to /js/<name>.<hash>.js by
   layouts/_partials/script-url.html (js.Build + fingerprint)
 - tsconfig.json — editor/type-check config only; the build ignores it
 - static/ — css/ (self-hosted bootstrap.min.css + custom.css), js/
@@ -64,6 +64,22 @@ No package.json or Makefile; Hugo CLI only (Netlify uses 0.164.0):
 - New-post checklist: create the zh/en pair with matching
   slug/translationKey; if a zh/en tag pair uses different names, add
   it to data/tag_translations.yaml. llms.txt updates itself.
+- Site search: `/search/` + `/en/search/` query a self-hosted
+  Meilisearch (search.gujiakai.top) straight over its REST API — no
+  SDK. The searchable corpus is built by Hugo: the `SearchIndex`
+  output format on `home` renders layouts/home.searchindex.json to
+  /search-index.json and /en/search-index.json (81 docs each, full
+  body, code blocks stripped). The VPS clones this repo, runs the
+  pinned Hugo, and pushes those files into the `blog_zh` / `blog_en`
+  indexes, so the Meilisearch admin key never leaves that box and
+  never enters GitHub Secrets. Two indexes, never merged: the zh/en
+  posts are 1:1 translations, so a merged index returns every post
+  twice for shared tokens like `docker`. Meilisearch document ids only
+  accept [a-zA-Z0-9_-], which is why the template emits a sanitized
+  `id` field instead of using RelPermalink. Endpoint and the public
+  search-only key live in `params.search` in config.yaml; leaving
+  either blank degrades /search/ to a disabled "not enabled" state
+  rather than breaking the build.
 - MarkdownRaw output: blog posts also emit their raw Markdown at
   /:year/:month/:slug.md (global `uglyURLs: true` + `noUgly` on
   HTML/RSS + cascade in content/*/blog/_index.md). Only blog posts get
@@ -88,11 +104,22 @@ No package.json or Makefile; Hugo CLI only (Netlify uses 0.164.0):
   utterances loader (compiled from assets/ts/) and the emaction
   reactions bundle (vendored in static/js/) are both served
   first-party, so script-src no longer lists any CDN; external
-  origins are Clarity, GA (googletagmanager), umami, and asciinema in
+  origins are Clarity, GA (googletagmanager), umami, asciinema in
   script-src, with utteranc.es (frame) and api-emaction.gujiakai.top
-  (connect) for the self-hosted widgets. Any new external
-  script/iframe/connect target must be added to the matching directive
-  or browsers will block it.
+  plus search.gujiakai.top (connect) for the self-hosted widgets and
+  Meilisearch. Any new external script/iframe/connect target must be
+  added to the matching directive or browsers will block it.
+- `hugo server` fast render does NOT rebuild the home-kind
+  /search-index.json when you edit a post — it keeps serving the old
+  one. Use `hugo server --disableFastRender` for any search work, or
+  you will chase a phantom "search can't find the post I just wrote".
+- The production build command adds `--panicOnWarning`, so a custom
+  output format without its template is a failed deploy, not a
+  warning. `--printPathWarnings` and `--printI18nWarnings` are worth
+  passing locally: the first turns a silent same-path collision (two
+  outputs clobbering each other) into a WARN, the second catches
+  missing i18n keys, which otherwise render as empty strings with no
+  build signal at all.
 
 ## Gotchas
 

--- a/assets/ts/search.ts
+++ b/assets/ts/search.ts
@@ -1,0 +1,256 @@
+/*
+ * 站内搜索：直接调用自建 Meilisearch 的 REST API，不引任何 SDK。
+ * 一次搜索就是一个 POST /indexes/{index}/search，官方 JS SDK 要多带几十 KB —
+ * 在一个特意删掉 jQuery 和 lightbox2 的仓库里不划算。
+ *
+ * CSP 约束（见 netlify.toml）：
+ *   - 由 script-url.html 编译成 /js/search.<hash>.js 外链加载，页面无内联 <script>
+ *   - 事件一律 addEventListener（script-src-attr 为 'none'，内联 onclick 会被拦）
+ *   - 结果用 createElement + textContent 构建，绝不用 innerHTML
+ *   - 请求目标域名必须在 connect-src 里；Meilisearch 自带 CORS 头并自行响应预检
+ */
+(function () {
+    'use strict';
+
+    interface MeiliFormatted {
+        t?: string;
+        s?: string;
+        b?: string;
+    }
+
+    interface MeiliHit {
+        u: string;
+        t: string;
+        s?: string;
+        g?: string[];
+        d?: string;
+        _formatted?: MeiliFormatted;
+    }
+
+    interface MeiliResponse {
+        hits?: MeiliHit[];
+        estimatedTotalHits?: number;
+    }
+
+    const app = document.getElementById('search-app');
+    if (!app) return;
+
+    const endpoint = (app.dataset.endpoint || '').replace(/\/+$/, '');
+    const apiKey = app.dataset.key || '';
+    const index = app.dataset.index || '';
+    const input = document.getElementById('search-input') as HTMLInputElement | null;
+    const form = document.getElementById('search-form') as HTMLFormElement | null;
+    const list = document.getElementById('search-results');
+    const status = document.getElementById('search-status');
+
+    // 没配 endpoint / key 时模板已渲染「暂不可用」并禁用了输入框，直接退出。
+    if (!endpoint || !apiKey || !index || !input || !list || !status) return;
+
+    const results: HTMLElement = list;
+    const statusLine: HTMLElement = status;
+    const field: HTMLInputElement = input;
+
+    /* Meilisearch 用这两个标记包裹命中片段。这里特意选控制字符：正文里不可能
+       出现，切分时没有歧义，也就不必去解析任何受用户输入影响的标记。 */
+    const HL_PRE = '';
+    const HL_POST = '';
+
+    const SEARCH_DEBOUNCE = 150;   // 重新渲染结果
+    const COMMIT_DEBOUNCE = 900;   // 写 URL，见 commitQuery 的说明
+    const LIMIT = 20;
+
+    let searchTimer = 0;
+    let commitTimer = 0;
+    let inflight: AbortController | null = null;
+    let lastCommitted: string | null = null;
+
+    /* ------------------------------------------------------------- 渲染 */
+
+    /* 把带高亮标记的字符串切成「普通文本 / <mark> 文本」交替的节点。
+       全程 textContent —— 即使正文含有 <script> 之类的字面量也只是文字。 */
+    function highlightInto(parent: HTMLElement, text: string): void {
+        if (!text) return;
+        const chunks = text.split(HL_PRE);
+        parent.appendChild(document.createTextNode(chunks[0]));
+        for (let i = 1; i < chunks.length; i++) {
+            const parts = chunks[i].split(HL_POST);
+            const mark = document.createElement('mark');
+            mark.textContent = parts[0];
+            parent.appendChild(mark);
+            if (parts.length > 1) {
+                parent.appendChild(document.createTextNode(parts.slice(1).join(HL_POST)));
+            }
+        }
+    }
+
+    function renderHits(hits: MeiliHit[]): void {
+        results.replaceChildren();
+        const frag = document.createDocumentFragment();
+
+        hits.forEach(function (hit) {
+            const fmt: MeiliFormatted = hit._formatted || {};
+            const li = document.createElement('li');
+            li.className = 'search-result';
+
+            const heading = document.createElement('h2');
+            heading.className = 'h5 search-result-title';
+            const link = document.createElement('a');
+            link.href = hit.u;
+            highlightInto(link, fmt.t || hit.t || '');
+            heading.appendChild(link);
+            li.appendChild(heading);
+
+            const meta = document.createElement('p');
+            meta.className = 'search-result-meta text-muted';
+            if (hit.d) {
+                const time = document.createElement('time');
+                time.dateTime = hit.d;
+                time.textContent = hit.d;
+                meta.appendChild(time);
+            }
+            (hit.g || []).forEach(function (tag) {
+                const badge = document.createElement('span');
+                badge.className = 'badge bg-secondary search-result-tag';
+                badge.textContent = '#' + tag;
+                meta.appendChild(badge);
+            });
+            if (meta.childNodes.length) li.appendChild(meta);
+
+            // 正文片段优先用裁剪并高亮过的 b，没有就退回摘要。
+            const snippet = document.createElement('p');
+            snippet.className = 'search-result-snippet';
+            highlightInto(snippet, fmt.b || fmt.s || hit.s || '');
+            if ((snippet.textContent || '').trim()) li.appendChild(snippet);
+
+            frag.appendChild(li);
+        });
+
+        results.appendChild(frag);
+    }
+
+    function setStatus(text: string): void {
+        statusLine.textContent = text;
+    }
+
+    /* --------------------------------------------------------- 查询 URL */
+
+    /* umami 和 GA4 都挂了 history.replaceState 并在每次 URL 变化时上报一次
+       pageview。若每个按键都写 ?q=，「docker」会变成 6 条 pageview。
+       所以渲染和写 URL 用两个独立计时器：结果 150ms 就刷新（手感即时），
+       URL 只在输入停下约 900ms、或按回车、或点击结果时才落一次。这样上报流
+       恰好是「一次真实搜索一行」，正是想要的 umami 报表。 */
+    function commitQuery(q: string): void {
+        if (q === lastCommitted) return;
+        lastCommitted = q;
+        const url = new URL(window.location.href);
+        if (q) url.searchParams.set('q', q);
+        else url.searchParams.delete('q');
+        window.history.replaceState(null, '', url.toString());
+    }
+
+    function scheduleCommit(q: string): void {
+        window.clearTimeout(commitTimer);
+        if (!q || q.length < 2) return;
+        commitTimer = window.setTimeout(function () { commitQuery(q); }, COMMIT_DEBOUNCE);
+    }
+
+    /* ------------------------------------------------------------- 请求 */
+
+    function run(q: string): void {
+        if (inflight) inflight.abort();
+        const controller = new AbortController();
+        inflight = controller;
+
+        setStatus(app!.dataset.labelSearching || '');
+
+        window.fetch(endpoint + '/indexes/' + encodeURIComponent(index) + '/search', {
+            method: 'POST',
+            signal: controller.signal,
+            headers: {
+                'Authorization': 'Bearer ' + apiKey,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                q: q,
+                limit: LIMIT,
+                // 只取展示需要的字段：正文全文有几 KB，跨太平洋回传纯属浪费。
+                attributesToRetrieve: ['u', 't', 's', 'g', 'd'],
+                attributesToHighlight: ['t', 's', 'b'],
+                attributesToCrop: ['b'],
+                cropLength: 45,
+                highlightPreTag: HL_PRE,
+                highlightPostTag: HL_POST
+            })
+        })
+            .then(function (res: Response) {
+                if (!res.ok) throw new Error('HTTP ' + res.status);
+                return res.json() as Promise<MeiliResponse>;
+            })
+            .then(function (data: MeiliResponse) {
+                const hits = data.hits || [];
+                renderHits(hits);
+                if (!hits.length) {
+                    setStatus(app!.dataset.labelEmpty || '');
+                    return;
+                }
+                const total = typeof data.estimatedTotalHits === 'number'
+                    ? data.estimatedTotalHits
+                    : hits.length;
+                setStatus((app!.dataset.labelCount || '%d').replace('%d', String(total)));
+            })
+            .catch(function (err: unknown) {
+                // 被下一次输入取消，不是错误
+                if (err instanceof Error && err.name === 'AbortError') return;
+                results.replaceChildren();
+                setStatus(app!.dataset.labelError || '');
+            });
+    }
+
+    function schedule(q: string): void {
+        window.clearTimeout(searchTimer);
+        if (!q) {
+            if (inflight) inflight.abort();
+            results.replaceChildren();
+            setStatus('');
+            commitQuery('');
+            return;
+        }
+        searchTimer = window.setTimeout(function () { run(q); }, SEARCH_DEBOUNCE);
+    }
+
+    /* ------------------------------------------------------------- 事件 */
+
+    field.addEventListener('input', function () {
+        const q = field.value.trim();
+        schedule(q);
+        scheduleCommit(q);
+    });
+
+    if (form) {
+        form.addEventListener('submit', function (e: Event) {
+            e.preventDefault();                 // 结果就在本页，不需要真正提交
+            const q = field.value.trim();
+            window.clearTimeout(searchTimer);
+            window.clearTimeout(commitTimer);
+            if (q) { run(q); commitQuery(q); }
+        });
+    }
+
+    // 点走结果之前把这次查询落进 URL，否则短查询永远进不了统计。
+    results.addEventListener('click', function (e: Event) {
+        const target = e.target;
+        if (target instanceof Element && target.closest('a')) {
+            window.clearTimeout(commitTimer);
+            commitQuery(field.value.trim());
+        }
+    });
+
+    /* 支持 /search/?q=xxx 直链：可分享、可回退，也让 umami 的报表直接告诉你
+       读者在搜什么。 */
+    const initial = new URLSearchParams(window.location.search).get('q');
+    if (initial) {
+        field.value = initial;
+        lastCommitted = initial.trim();
+        run(initial.trim());
+    }
+}());

--- a/config.yaml
+++ b/config.yaml
@@ -62,6 +62,18 @@ outputFormats:
     mediaType: text/markdown
     isPlainText: true
     isHTML: false
+  # 搜索索引：由 layouts/home.searchindex.json 按语言在构建时生成
+  # （/search-index.json 与 /en/search-index.json）。VPS 上的 Meilisearch 直接
+  # clone 本仓库、跑 hugo，再把这两个文件推进 blog_zh / blog_en —— 写入用的
+  # admin key 因此始终留在那台机器上，不必进 GitHub Secrets。
+  # 不需要 noUgly：uglyURLs 不影响 home kind 的输出路径（baseName 决定文件名）。
+  # notAlternative 让它不进入 head.html 的 <link rel=alternate>。
+  SearchIndex:
+    baseName: search-index
+    mediaType: application/json
+    isPlainText: true
+    isHTML: false
+    notAlternative: true
   # llms.txt（https://llmstxt.org）：由 layouts/home.llms.txt 按语言在构建时生成
   # （/llms.txt 与 /en/llms.txt），取代过去手工维护、容易过期的 static/ 副本
   LLMS:
@@ -76,6 +88,8 @@ outputs:
     - HTML
     - RSS
     - LLMS
+    # 对 zh/en 同时生效，无需 languages.*.outputs 覆盖（覆盖是整体替换而非合并）
+    - SearchIndex
   section:
     - HTML
     - RSS
@@ -122,6 +136,9 @@ languages:
         - name: "关于"
           url: "/about/"
           weight: 5
+        - name: "搜索"
+          url: "/search/"
+          weight: 6
   en:
     label: "English"
     locale: "en-US"
@@ -150,6 +167,9 @@ languages:
         - name: "About"
           url: "/about/"
           weight: 5
+        - name: "Search"
+          url: "/search/"
+          weight: 6
 
 # 全局参数（作为默认值）
 params:
@@ -159,6 +179,17 @@ params:
   footer: "&copy; 2022-{Year} Made with ❤️ By Jiakai"
   # 本地、分支部署和 Deploy Preview 默认为 false；Netlify 仅在 production context 覆盖为 true。
   enableAnalytics: false
+  # 站内搜索：前端直接打自建 Meilisearch 的 REST API（不引 SDK）。
+  # - endpoint 留空时 /search/ 显示「暂不可用」，构建与部署照常，不会报错；
+  #   接好 VPS 后填上即可，无需改模板。
+  # - apiKey 必须是只读的 search-only key（Meilisearch /keys 里 actions 仅
+  #   ["search"]），它会出现在页面源码里，这是设计如此；绝不可填 master key。
+  # - 索引名按语言拼成 blog_zh / blog_en，两个索引分开：81 篇中英是一一对应的
+  #   译文，合并后任何命中共享词（docker、claude）的查询都会把同一篇返回两次。
+  search:
+    endpoint: ""
+    apiKey: ""
+    indexPrefix: "blog_"
 
 # markup设置
 markup:

--- a/content/en/search.md
+++ b/content/en/search.md
@@ -1,0 +1,9 @@
+---
+title: "Search"
+slug: "search"
+translationKey: "search"
+layout: "search"
+noindex: true
+sitemap:
+  disable: true
+---

--- a/content/zh/search.md
+++ b/content/zh/search.md
@@ -1,0 +1,9 @@
+---
+title: "搜索"
+slug: "search"
+translationKey: "search"
+layout: "search"
+noindex: true
+sitemap:
+  disable: true
+---

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -106,3 +106,19 @@
   translation: "Close image viewer"
 - id: addReaction
   translation: "Add reaction"
+- id: searchLabel
+  translation: "Search posts"
+- id: searchPlaceholder
+  translation: "Search posts by keyword…"
+- id: searchResultCount
+  translation: "%d posts found"
+- id: searchNoResults
+  translation: "No matching posts. Try a different keyword."
+- id: searchSearching
+  translation: "Searching…"
+- id: searchError
+  translation: "Search is temporarily unavailable. Please try again later."
+- id: searchUnavailable
+  translation: "Search is not enabled yet."
+- id: searchNoScript
+  translation: "Site search needs JavaScript. You can also browse every post by year:"

--- a/i18n/zh.yaml
+++ b/i18n/zh.yaml
@@ -106,3 +106,19 @@
   translation: "关闭图片查看器"
 - id: addReaction
   translation: "添加表情回应"
+- id: searchLabel
+  translation: "搜索文章"
+- id: searchPlaceholder
+  translation: "输入关键词搜索文章…"
+- id: searchResultCount
+  translation: "找到 %d 篇文章"
+- id: searchNoResults
+  translation: "没有找到匹配的文章，换个关键词试试。"
+- id: searchSearching
+  translation: "搜索中…"
+- id: searchError
+  translation: "搜索服务暂时无法访问，请稍后再试。"
+- id: searchUnavailable
+  translation: "搜索功能尚未启用。"
+- id: searchNoScript
+  translation: "站内搜索需要 JavaScript。你也可以按年份浏览全部文章："

--- a/layouts/_partials/head.html
+++ b/layouts/_partials/head.html
@@ -67,7 +67,9 @@
     {{- if $is404 }}
     <meta name="robots" content="noindex, nofollow, noarchive">
     {{- else }}
-    {{- if $isThinTerm }}
+    {{/* .Params.noindex 供 /search/ 这类工具页使用：搜索结果页对搜索引擎是
+         低价值近重复内容，且会凭 ?q= 生成无穷可抓取 URL。 */}}
+    {{- if or $isThinTerm .Params.noindex }}
     <meta name="robots" content="noindex, follow">
     {{- end }}
     <link rel="canonical" href="{{ $canonical }}" />

--- a/layouts/_partials/scripts.html
+++ b/layouts/_partials/scripts.html
@@ -11,6 +11,9 @@
 {{- if $hasCode }}
 <script defer src="{{ partialCached "script-url.html" "copy-code" "copy-code" }}"></script>
 {{- end }}
+{{- if eq .Layout "search" }}
+<script defer src="{{ partialCached "script-url.html" "search" "search" }}"></script>
+{{- end }}
 <script defer src="{{ partialCached "script-url.html" "site-controls" "site-controls" }}"></script>
 {{- if and .IsPage (eq .Type "blog") }}
 <script defer src="{{ partialCached "script-url.html" "back-to-top" "back-to-top" }}"></script>

--- a/layouts/home.searchindex.json
+++ b/layouts/home.searchindex.json
@@ -1,0 +1,38 @@
+{{- /* 每种语言各生成一份：/search-index.json 与 /en/search-index.json。
+       site.RegularPages 已按当前语言过滤，不必手动区分 zh/en。
+       消费方是 VPS 上的 Meilisearch —— 它 clone 本仓库、跑 hugo，再把这里
+       生成的数组推进 blog_zh / blog_en 两个索引。 */ -}}
+{{- $docs := slice -}}
+{{- /* where "Section" "blog" 天然只选中 81 篇正文：归档页是 branch bundle
+       （_index.md），不算 RegularPage；about.md / til.md 的 Section 为空。
+       不需要维护黑名单。 */ -}}
+{{- range where site.RegularPages "Section" "blog" -}}
+  {{- /* Meilisearch 的文档主键只接受 [a-zA-Z0-9_-]，RelPermalink 里的斜杠
+         不合法，因此把非法字符统一替换；结果在单语言索引内天然唯一。 */ -}}
+  {{- $id := .RelPermalink | replaceRE `[^a-zA-Z0-9_-]` "-" -}}
+  {{- /* .Content 是 shortcode 渲染后的 HTML。先剥代码块再 plainify，否则
+         每篇文章都会命中 func / const / sudo 这类语法噪声。本站
+         markup.highlight.lineNumbersInTable 为 true，高亮块是嵌套 table，
+         要三条 replaceRE 才清得干净。用 .Content 而非 .RawContent：后者仍
+         含未展开的短代码字面量。 */ -}}
+  {{- $body := .Content
+        | replaceRE `(?s)<div class="highlight">.*?</div>\s*</div>` " "
+        | replaceRE `(?s)<pre[^>]*>.*?</pre>` " "
+        | replaceRE `(?s)<code[^>]*>.*?</code>` " "
+        | plainify | htmlUnescape | replaceRE `\s+` " " | chomp -}}
+  {{- $docs = $docs | append (dict
+      "id" $id
+      "u" .RelPermalink
+      "t" .Title
+      "s" (.Summary | plainify | htmlUnescape | replaceRE `\s+` " " | chomp)
+      "g" (.Params.tags | default slice)
+      "d" (.Date.Format "2006-01-02")
+      "b" $body
+  ) -}}
+{{- end -}}
+{{- /* noHTMLEscape：否则 & < > 会被转成实体，既撑大索引，也会让 Meilisearch
+       返回的高亮偏移与原文对不上。
+       正文不截断 —— 消费方是服务端引擎，全文检索正是自建 Meilisearch 的意义。
+       若日后要加浏览器端兜底索引，把 $body 换成 (substr $body 0 1200) 即可，
+       中文索引会从约 490 KB 降到约 220 KB。 */ -}}
+{{- $docs | jsonify (dict "noHTMLEscape" true) -}}

--- a/layouts/search.html
+++ b/layouts/search.html
@@ -1,0 +1,47 @@
+{{ define "main" }}
+{{- $search := site.Params.search | default dict -}}
+{{- $endpoint := $search.endpoint | default "" -}}
+{{- $apiKey := $search.apiKey | default "" -}}
+{{- $index := printf "%s%s" ($search.indexPrefix | default "blog_") site.Language.Lang -}}
+{{- $configured := and $endpoint $apiKey -}}
+
+<h1 class="mb-4">🔍 {{ .Title }}</h1>
+
+{{/* <search> 自带 search landmark（Baseline 2023-10），不必再给 form 加
+     role="search"，两者并存会产生重复地标。 */}}
+<search class="site-search-page mb-4">
+  <form id="search-form" action="{{ "/search/" | relLangURL }}" method="get" role="none">
+    <label class="visually-hidden" for="search-input">{{ i18n "searchLabel" }}</label>
+    <input type="search" id="search-input" name="q" class="form-control form-control-lg"
+           placeholder="{{ i18n "searchPlaceholder" }}"
+           autocomplete="off" autocapitalize="off" spellcheck="false"
+           {{ if $configured }}autofocus{{ else }}disabled{{ end }}>
+  </form>
+</search>
+
+{{/* 所有配置经 data-* 传给外部脚本：CSP 无 'unsafe-inline'，不能内联 <script>；
+     script-src-attr 为 'none'，事件必须走 addEventListener。
+     apiKey 是只读的 search-only key，出现在页面源码里是设计如此。 */}}
+<div id="search-app"
+     data-endpoint="{{ $endpoint }}"
+     data-key="{{ $apiKey }}"
+     data-index="{{ $index }}"
+     data-label-count="{{ i18n "searchResultCount" }}"
+     data-label-empty="{{ i18n "searchNoResults" }}"
+     data-label-error="{{ i18n "searchError" }}"
+     data-label-searching="{{ i18n "searchSearching" }}">
+
+  {{/* role="status" 隐含 aria-live="polite" 与 aria-atomic="true"，是 W3C
+       ARIA22 里公布结果数量的标准做法，满足 WCAG 4.1.3。 */}}
+  <p id="search-status" class="text-muted" role="status">
+    {{- if not $configured }}{{ i18n "searchUnavailable" }}{{ end -}}
+  </p>
+
+  <ol id="search-results" class="list-unstyled search-results"></ol>
+</div>
+
+<noscript>
+  <p class="text-muted">{{ i18n "searchNoScript" }}</p>
+  <p><a href="{{ "/archive/" | relLangURL }}">{{ i18n "archiveTitle" }}</a></p>
+</noscript>
+{{ end }}

--- a/netlify.toml
+++ b/netlify.toml
@@ -39,7 +39,7 @@
   [headers.values]
     # Executable inline markup is forbidden. Utterances is embedded by the local loader, and the emaction bundle
     # remains patched and self-hosted; only their runtime frame/API origins are trusted.
-    Content-Security-Policy = "default-src 'self'; script-src 'self' https://*.clarity.ms https://www.googletagmanager.com https://umami.gujiakai.top https://asciinema.org https://static.cloudflareinsights.com; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'none'; img-src * data: blob:; media-src https:; font-src 'self' data:; connect-src 'self' https://*.clarity.ms https://*.google-analytics.com https://analytics.google.com https://*.analytics.google.com https://www.google.com https://www.googletagmanager.com https://stats.g.doubleclick.net https://umami.gujiakai.top https://api-emaction.gujiakai.top https://cloudflareinsights.com; frame-src https://utteranc.es https://asciinema.org; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' https://*.clarity.ms https://www.googletagmanager.com https://umami.gujiakai.top https://asciinema.org https://static.cloudflareinsights.com; script-src-attr 'none'; style-src 'self'; style-src-elem 'self'; style-src-attr 'none'; img-src * data: blob:; media-src https:; font-src 'self' data:; connect-src 'self' https://*.clarity.ms https://*.google-analytics.com https://analytics.google.com https://*.analytics.google.com https://www.google.com https://www.googletagmanager.com https://stats.g.doubleclick.net https://umami.gujiakai.top https://api-emaction.gujiakai.top https://search.gujiakai.top https://cloudflareinsights.com; frame-src https://utteranc.es https://asciinema.org; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'self'"
     X-Frame-Options = "SAMEORIGIN"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
@@ -61,6 +61,39 @@
     X-Robots-Tag = "noindex, follow, noarchive"
     Content-Type = "text/markdown; charset=UTF-8"
     Cache-Control = "public, max-age=300, must-revalidate"
+
+# 搜索索引 JSON：每次发文都会变，绝不能沿用 /js/* 的 immutable 规则（那会把它
+# 在浏览器里冻结一年）。Netlify 默认策略正合适：浏览器每次 revalidate（命中时
+# 返回 304、零字节），CDN 缓存一年但每次部署自动失效。
+# 它是给 VPS 上的 Meilisearch 摄取用的中间产物，不是给搜索引擎看的。
+[[headers]]
+  for = "/search-index.json"
+  [headers.values]
+    Content-Type = "application/json; charset=UTF-8"
+    Cache-Control = "public, max-age=0, must-revalidate"
+    Netlify-CDN-Cache-Control = "public, s-maxage=31536000, must-revalidate"
+    X-Robots-Tag = "noindex, follow"
+
+[[headers]]
+  for = "/en/search-index.json"
+  [headers.values]
+    Content-Type = "application/json; charset=UTF-8"
+    Cache-Control = "public, max-age=0, must-revalidate"
+    Netlify-CDN-Cache-Control = "public, s-maxage=31536000, must-revalidate"
+    X-Robots-Tag = "noindex, follow"
+
+# 搜索页：HTML 里已有 noindex meta（head.html 的 .Params.noindex 分支），
+# HTTP 层再兜一次。注意不要在 robots.txt 里 Disallow /search/ —— 被 Disallow
+# 的 URL 不会被抓取，noindex 因此永远读不到，反而可能长期留存为纯 URL 条目。
+[[headers]]
+  for = "/search/*"
+  [headers.values]
+    X-Robots-Tag = "noindex, follow"
+
+[[headers]]
+  for = "/en/search/*"
+  [headers.values]
+    X-Robots-Tag = "noindex, follow"
 
 # 404 文件本身可能被直接请求并以 200 返回；HTTP 与 HTML 两层都明确禁止索引。
 [[headers]]

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1369,3 +1369,59 @@ emoji-reaction button:focus-visible {
         animation-iteration-count: 1 !important;
     }
 }
+
+/* ---------------------------------------------------------------------------
+   站内搜索（/search/ 与 /en/search/）
+   结果由 assets/ts/search.ts 用 createElement + textContent 构建，
+   高亮片段是真正的 <mark> 元素，因此这里只需要排版，不涉及任何注入面。
+--------------------------------------------------------------------------- */
+
+.site-search-page input[type="search"] {
+    border-radius: 0.5rem;
+}
+
+.search-results {
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+    margin-top: 1.5rem;
+}
+
+.search-result-title {
+    margin-bottom: 0.35rem;
+}
+
+.search-result-title a {
+    text-decoration: none;
+}
+
+.search-result-title a:hover,
+.search-result-title a:focus-visible {
+    text-decoration: underline;
+}
+
+.search-result-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.5rem;
+    margin-bottom: 0.4rem;
+    font-size: 0.85rem;
+}
+
+.search-result-tag {
+    font-weight: 400;
+}
+
+.search-result-snippet {
+    margin-bottom: 0;
+    /* Meilisearch 返回的是裁剪过的片段，长度可控，但中文长串仍需强制换行 */
+    overflow-wrap: anywhere;
+}
+
+/* 命中高亮沿用 Bootstrap 的 <mark>，但去掉默认内边距，
+   避免在中文正文里把行高撑开。 */
+.search-results mark {
+    padding: 0.05em 0.1em;
+    border-radius: 0.15em;
+}


### PR DESCRIPTION
Adds `/search/` and `/en/search/`, backed by a self-hosted Meilisearch on `search.gujiakai.top`, queried directly over its REST API — no SDK.

## How the index is built

A new `SearchIndex` output format on `home` renders `layouts/home.searchindex.json` to `/search-index.json` and `/en/search-index.json` (81 docs each, full body, code blocks stripped). The VPS clones this repo, runs the pinned Hugo and pushes those files into `blog_zh` / `blog_en` — so the Meilisearch **admin key never leaves that box** and never enters GitHub Secrets.

Two indexes, never merged: the zh/en posts are 1:1 translations, so a merged index would return every post twice for shared tokens like `docker`.

## Why not Pagefind

Pagefind is the usual answer for Hugo, and it was tested rather than assumed — built against this site, served under the exact production CSP, driven with headless Chrome. It fails hard:

```
CompileError: WebAssembly.instantiate(): ... violates the following Content
Security policy directive because 'unsafe-eval' is not an allowed source of
script in ... "script-src 'self'"
```

It needs `script-src 'wasm-unsafe-eval'`, and Chinese indexing additionally requires the 52 MB `pagefind_extended` binary in the Netlify build. Two design values traded away for a 162-document corpus.

## CSP

**Only `connect-src` changes.** The client is an external fingerprinted script, all events are `addEventListener` (`script-src-attr` is `'none'`), and results are built with `createElement` + `textContent` — never `innerHTML`. Meilisearch sends its own CORS headers, so Caddy adds none (two `Access-Control-Allow-Origin` headers is a hard failure in every browser).

## Analytics

Results refresh at 150 ms, but `?q=` is committed only after ~900 ms idle, on Enter, or on result click. umami and GA4 both hook `history.replaceState` and fire a pageview per URL change, so a per-keystroke `replaceState` would turn `docker` into six pageviews.

## Deploy-safe as-is

`params.search.endpoint` and `apiKey` are blank, so `/search/` renders a disabled "not enabled" state. This merges and deploys safely before the backend is wired up. `apiKey` must be a **search-only** key — it is public by design and appears in page source.

## Validation

- `hugo --gc --minify --panicOnWarning --printPathWarnings --printI18nWarnings` — clean, zero WARN
- `npx --yes --package typescript@5.9.3 tsc -p tsconfig.json` — clean
- 81 docs per language, all ids unique and matching `^[a-zA-Z0-9_-]+$` (Meilisearch rejects slashes, so `RelPermalink` could not be the primary key)
- 0 of 81 zh docs carry code-fence residue
- Bundle loads only on the 2 search pages, not the other 296
- `noindex` + sitemap exclusion on both; zh↔en hreflang pair via `translationKey`
- No `/search.json` path collision (verified with `--printPathWarnings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpsqV7c8sHU7TECttFxtMo